### PR TITLE
Adds random functionality to search

### DIFF
--- a/src/Backend/mongo.ts
+++ b/src/Backend/mongo.ts
@@ -36,6 +36,7 @@ export type AggregationPipelineStage<T> =
     { $match: AggregationQuery<QueryFieldOf<T>> } |
     { $addFields: { [k: string]: QueryOperation<T> } } |
     { $sort: { [key in keyof T]?: -1 | 1 } } |
+    { $sample: { size: number } } |
     undefined;
 
 let connection: MongoClient;

--- a/src/Website/api.ts
+++ b/src/Website/api.ts
@@ -215,6 +215,7 @@ api.get("/search", async (request, response) => {
     let spp = request.query.spp || 15;
     spp < 1 && (spp = 15);
     spp > 100 && (spp = 100);
+    let random = request.query.random ? true : false;
     try {
         Object.keys(request.query)
             .filter(attr => request.query[attr] === '')
@@ -227,7 +228,7 @@ api.get("/search", async (request, response) => {
                         return { [k]: new RegExp(request.query.q, 'i') };
                     })
                 }
-            }, { $sort: { id: 1 } }], spp, page);
+            }, random ? { $sample: { size: 1 } } : { $sort: { id: 1 } }], spp, page);
             response.json(results);
         } else { // Advanced search
             const data = ['date_added', 'format', 'creator', 'hash', 'name', 'species',
@@ -253,7 +254,7 @@ api.get("/search", async (request, response) => {
                         };
                     })
                 }
-            }, { $sort: { id: 1 } }], spp, page);
+            }, random ? { $sample: { size: 1 } } : { $sort: { id: 1 } }], spp, page);
             response.json(results);
         }
     } catch (e) {


### PR DESCRIPTION
This is kind of a lazy solution, but it would be nice to be able to filter the `/random` API to get specific results (e.g.: "I want a random Rhyperior set"). But instead of doing that I just added it to `/search` using [`$sample`](https://docs.mongodb.com/manual/reference/operator/aggregation/sample/). Dogars is a bitch to get working locally, so I haven't tested this yet.