### PR TITLE
Fixes issue where creating a set with no other sets errors

### DIFF
--- a/src/Backend/mongo.ts
+++ b/src/Backend/mongo.ts
@@ -256,7 +256,7 @@ export const createNewSet = async (sdata: {
     nset = { ...nset, ...pok };
     nset.date_added = +new Date();
     total++;
-    nset.id = (await SetsCollection.find().sort({ id: -1 }).toArray())[0].id + 1;
+    nset.id = ((await SetsCollection.find().sort({ id: -1 }).toArray())[0]?.id || 0) + 1;
     await SetsCollection.insertOne(toDBSet(nset));
     return nset;
 }


### PR DESCRIPTION
Self explanatory. Accessing the `id` field when there are no sets errors out, making it impossible to add sets to a fresh database.

Fixes #9 