### PR TITLE
Updates validation logic to validate a single set instead of team

### DIFF
--- a/src/Website/poke-utils.ts
+++ b/src/Website/poke-utils.ts
@@ -147,7 +147,7 @@ export module pokeUtils {
         clone.moves = f(clone.moves.join('/')).slice(0, 4);
         let validator = TeamValidator.get(set.format);
 
-        let res = validator.validateTeam([clone as PokemonSet]);
+        let res = validator.validateSet(clone as PokemonSet, {});
         if (res && res.length)
             return res;
         return null;


### PR DESCRIPTION
See title. Allows for validating doubles sets. Changes `validateTeam` to `validateSet`. Tested locally and successfully imported a fastpoke into doubles

![fastpoke](https://i.imgur.com/8MYQ8sy.png)